### PR TITLE
Parse geolocation data correctly

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,9 +18,6 @@
             "url": "https://packages.drupal.org/8"
         }
     },
-    "require": {
-        "drupal/menu_ui": "*"
-    },
     "require-dev": {
         "phpunit/phpunit": "^8",
         "squizlabs/php_codesniffer": "^3",

--- a/config/optional/core.entity_form_display.node.event.default.yml
+++ b/config/optional/core.entity_form_display.node.event.default.yml
@@ -9,7 +9,9 @@ dependencies:
     - field.field.node.event.field_campus
     - field.field.node.event.field_end_date
     - field.field.node.event.field_future_dates
-    - field.field.node.event.field_geolocation
+    - field.field.node.event.field_geolocation_latitude
+    - field.field.node.event.field_geolocation_longitude
+    - field.field.node.event.field_geolocation_place_id
     - field.field.node.event.field_libcal_categories
     - field.field.node.event.field_libcal_color
     - field.field.node.event.field_libcal_featured_image
@@ -93,7 +95,23 @@ content:
       size: 60
       placeholder: ''
     third_party_settings: {  }
-  field_geolocation:
+  field_geolocation_latitude:
+    type: string_textfield
+    weight: 23
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_geolocation_longitude:
+    type: string_textfield
+    weight: 23
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_geolocation_place_id:
     type: string_textfield
     weight: 23
     region: content

--- a/config/optional/core.entity_form_display.node.event.default.yml
+++ b/config/optional/core.entity_form_display.node.event.default.yml
@@ -96,7 +96,7 @@ content:
       placeholder: ''
     third_party_settings: {  }
   field_geolocation_latitude:
-    type: string_textfield
+    type: number
     weight: 23
     region: content
     settings:
@@ -104,7 +104,7 @@ content:
       placeholder: ''
     third_party_settings: {  }
   field_geolocation_longitude:
-    type: string_textfield
+    type: number
     weight: 23
     region: content
     settings:

--- a/config/optional/core.entity_view_display.node.event.default.yml
+++ b/config/optional/core.entity_view_display.node.event.default.yml
@@ -95,7 +95,7 @@ content:
     weight: 17
     region: content
   field_geolocation_latitude:
-    type: string
+    type: number_float
     label: above
     settings:
       link_to_entity: false
@@ -103,7 +103,7 @@ content:
     weight: 16
     region: content
   field_geolocation_longitude:
-    type: string
+    type: number_float
     label: above
     settings:
       link_to_entity: false

--- a/config/optional/core.entity_view_display.node.event.default.yml
+++ b/config/optional/core.entity_view_display.node.event.default.yml
@@ -95,7 +95,7 @@ content:
     weight: 17
     region: content
   field_geolocation_latitude:
-    type: number_float
+    type: number_decimal
     label: above
     settings:
       link_to_entity: false
@@ -103,7 +103,7 @@ content:
     weight: 16
     region: content
   field_geolocation_longitude:
-    type: number_float
+    type: number_decimal
     label: above
     settings:
       link_to_entity: false

--- a/config/optional/core.entity_view_display.node.event.default.yml
+++ b/config/optional/core.entity_view_display.node.event.default.yml
@@ -9,7 +9,9 @@ dependencies:
     - field.field.node.event.field_campus
     - field.field.node.event.field_end_date
     - field.field.node.event.field_future_dates
-    - field.field.node.event.field_geolocation
+    - field.field.node.event.field_geolocation_latitude
+    - field.field.node.event.field_geolocation_longitude
+    - field.field.node.event.field_geolocation_place_id
     - field.field.node.event.field_libcal_categories
     - field.field.node.event.field_libcal_color
     - field.field.node.event.field_libcal_featured_image
@@ -92,7 +94,23 @@ content:
     third_party_settings: {  }
     weight: 17
     region: content
-  field_geolocation:
+  field_geolocation_latitude:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 16
+    region: content
+  field_geolocation_longitude:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 16
+    region: content
+  field_geolocation_place_id:
     type: string
     label: above
     settings:

--- a/config/optional/core.entity_view_display.node.event.teaser.yml
+++ b/config/optional/core.entity_view_display.node.event.teaser.yml
@@ -11,7 +11,9 @@ dependencies:
     - field.field.node.event.field_end_date
     - field.field.node.event.field_featured_image
     - field.field.node.event.field_future_dates
-    - field.field.node.event.field_geolocation
+    - field.field.node.event.field_geolocation_latitude
+    - field.field.node.event.field_geolocation_longitude
+    - field.field.node.event.field_geolocation_place_id
     - field.field.node.event.field_libcal_categories
     - field.field.node.event.field_libcal_color
     - field.field.node.event.field_libcal_id
@@ -54,7 +56,9 @@ hidden:
   field_end_date: true
   field_featured_image: true
   field_future_dates: true
-  field_geolocation: true
+  field_geolocation_latitude: true
+  field_geolocation_longitude: true
+  field_geolocation_place_id: true
   field_libcal_categories: true
   field_libcal_color: true
   field_libcal_id: true

--- a/config/optional/field.field.node.event.field_geolocation_latitude.yml
+++ b/config/optional/field.field.node.event.field_geolocation_latitude.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_geolocation_latitude
+    - node.type.event
+id: node.event.field_geolocation_latitude
+field_name: field_geolocation_latitude
+entity_type: node
+bundle: event
+label: Geolocation Latitude
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: float

--- a/config/optional/field.field.node.event.field_geolocation_longitude.yml
+++ b/config/optional/field.field.node.event.field_geolocation_longitude.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_geolocation_longitude
+    - node.type.event
+id: node.event.field_geolocation_longitude
+field_name: field_geolocation_longitude
+entity_type: node
+bundle: event
+label: Geolocation Longitude
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: float

--- a/config/optional/field.field.node.event.field_geolocation_place_id.yml
+++ b/config/optional/field.field.node.event.field_geolocation_place_id.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_geolocation_place_id
+    - node.type.event
+id: node.event.field_geolocation_place_id
+field_name: field_geolocation_place_id
+entity_type: node
+bundle: event
+label: Geolocation Place-id
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/optional/field.storage.node.field_geolocation_latitude.yml
+++ b/config/optional/field.storage.node.field_geolocation_latitude.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_geolocation_latitude
+field_name: field_geolocation_latitude
+entity_type: node
+type: float
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/optional/field.storage.node.field_geolocation_longitude.yml
+++ b/config/optional/field.storage.node.field_geolocation_longitude.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_geolocation_longitude
+field_name: field_geolocation_longitude
+entity_type: node
+type: float
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/optional/field.storage.node.field_geolocation_place_id.yml
+++ b/config/optional/field.storage.node.field_geolocation_place_id.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_geolocation_place_id
+field_name: field_geolocation_place_id
+entity_type: node
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/optional/views.view.workshop_events.yml
+++ b/config/optional/views.view.workshop_events.yml
@@ -4,7 +4,9 @@ dependencies:
   config:
     - field.storage.node.body
     - field.storage.node.field_end_date
-    - field.storage.node.field_geolocation
+    - field.storage.node.field_geolocation_latitude
+    - field.storage.node.field_geolocation_longitude
+    - field.storage.node.field_geolocation_place_id
     - field.storage.node.field_libcal_url
     - field.storage.node.field_location
     - field.storage.node.field_presenter
@@ -1427,10 +1429,136 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-        field_geolocation:
-          id: field_geolocation
-          table: node__field_geolocation
-          field: field_geolocation
+        field_geolocation_latitude:
+          id: field_geolocation_latitude
+          table: node__field_geolocation_latitude
+          field: field_geolocation_latitude
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        field_geolocation_longitude:
+          id: field_geolocation_longitude
+          table: node__field_geolocation_longitude
+          field: field_geolocation_longitude
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        field_geolocation_place_id:
+          id: field_geolocation_place_id
+          table: node__field_geolocation_place_id
+          field: field_geolocation_place_id
           relationship: none
           group_type: group
           admin_label: ''
@@ -1926,7 +2054,9 @@ display:
       tags:
         - 'config:field.storage.node.body'
         - 'config:field.storage.node.field_end_date'
-        - 'config:field.storage.node.field_geolocation'
+        - 'config:field.storage.node.field_geolocation_latitude'
+        - 'config:field.storage.node.field_geolocation_longitude'
+        - 'config:field.storage.node.field_geolocation_place_id'
         - 'config:field.storage.node.field_libcal_url'
         - 'config:field.storage.node.field_location'
         - 'config:field.storage.node.field_presenter'
@@ -2445,10 +2575,136 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-        field_geolocation:
-          id: field_geolocation
-          table: node__field_geolocation
-          field: field_geolocation
+        field_geolocation_latitude:
+          id: field_geolocation_latitude
+          table: node__field_geolocation_latitude
+          field: field_geolocation_latitude
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        field_geolocation_longitude:
+          id: field_geolocation_longitude
+          table: node__field_geolocation_longitude
+          field: field_geolocation_longitude
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        field_geolocation_place_id:
+          id: field_geolocation_place_id
+          table: node__field_geolocation_place_id
+          field: field_geolocation_place_id
           relationship: none
           group_type: group
           admin_label: ''
@@ -2945,7 +3201,9 @@ display:
       tags:
         - 'config:field.storage.node.body'
         - 'config:field.storage.node.field_end_date'
-        - 'config:field.storage.node.field_geolocation'
+        - 'config:field.storage.node.field_geolocation_latitude'
+        - 'config:field.storage.node.field_geolocation_longitude'
+        - 'config:field.storage.node.field_geolocation_place_id'
         - 'config:field.storage.node.field_libcal_url'
         - 'config:field.storage.node.field_location'
         - 'config:field.storage.node.field_presenter'

--- a/libcal.module
+++ b/libcal.module
@@ -47,7 +47,6 @@ function libcal_theme()
 function libcal_cron()
 {
    startDownloadLibCalEvents();
-
 }
 
 /**
@@ -60,36 +59,25 @@ function startDownloadLibCalEvents() {
   // set all event exist to pasted then turn on any event downlaodeable from Libcal will be turn off
   $service->updatePastFieldEventNode(true);
 
-  // Download events regards to the calenedar id(s)
-  if (!empty($config->get('calendar-id')) || $config->get('tags') != -1 ) {
-    $ids = $config->get('calendar-id');
-    if(strpos($ids, ',') !== false ) {
-      $calendar_ids = explode(',', $ids);
-      foreach ($calendar_ids as $cid) {
-        $result = $service->get("events?cal_id=". $cid)->events;
-        $service->libcalEventToNode($result);
-      }
-    }else {
-      $result = $service->get("events?cal_id=". $ids)->events;
+  // Download events regards to the calendar id(s)
+  if (!empty($config->get('calendar-id')) && $config->get('calendar-id') != -1 ) {
+    $calendar_ids = explode(',', $config->get('calendar-id'));
+
+    foreach ($calendar_ids as $cid) {
+      $result = $service->get("events?cal_id=$cid&limit=100")->events;
       $service->libcalEventToNode($result);
     }
   }
 
   // Download events regards to tag id(s)
-  if (!empty($config->get('tags'))  || $config->get('tags') != -1 ) {
-    $tags = $config->get('tags');
-    if(strpos($tags, ',') !== false ) {
-      $tag_ids = explode(',', $tags);
-      foreach ($tag_ids as $tid) {
-        $result =  $service->get("event_search?search=*&tag=$tid&limit=100")->events;
-        $service->libcalEventToNode($result);
-      }
-    }else {
-      $result =$service->get("event_search?search=*&tag=$tags&limit=100")->events;
+  if (!empty($config->get('tags')) && $config->get('tags') != -1 ) {
+    $tag_ids = explode(',', $config->get('tags'));
+
+    foreach ($tag_ids as $tid) {
+      $result =  $service->get("event_search?search=*&tag=$tid&limit=100")->events;
       $service->libcalEventToNode($result);
     }
   }
-
 }
 
 /**

--- a/src/EventDownloadService.php
+++ b/src/EventDownloadService.php
@@ -223,9 +223,9 @@ class EventDownloadService implements EventDownloadServiceInterface
             'field_seats_taken' => !empty($event->seats_taken)? $event->seats_taken: 0,
             'field_wait_list' => !empty($event->wait_list) ? $event->wait_list: 0,
             'field_past_event' => 0,
-            'field_geolocation_latitude' => $event->geolocation->latitude,
-            'field_geolocation_longitude' => $event->geolocation->longitude,
-            'field_geolocation_place_id' => $event->geolocation->{'place-id'}
+            'field_geolocation_latitude' => (isset($event->geolocation->latitude)) ? $event->geolocation->latitude : null,
+            'field_geolocation_longitude' => (isset($event->geolocation->longitude)) ? $event->geolocation->longitude : null,
+            'field_geolocation_place_id' => (isset($event->geolocation->{'place-id'})) ? $event->geolocation->{'place-id'} : null
         ];
 
         $node = Node::create($params);
@@ -288,9 +288,10 @@ class EventDownloadService implements EventDownloadServiceInterface
             $eventNode->set('field_seats_taken',(!empty($event->seats_taken)? $event->seats_taken : 0));
             $eventNode->set('field_wait_list', (!empty($event->wait_list) ? $event->wait_list: 0));
             $eventNode->set('field_past_event', false);
-            $eventNode->set('field_geolocation_latitude', $event->geolocation->latitude);
-            $eventNode->set('field_geolocation_longitude', $event->geolocation->longitude);
-            $eventNode->set('field_geolocation_place_id', $event->geolocation->{'place-id'});
+
+            $eventNode->set('field_geolocation_latitude', (isset($event->geolocation->latitude)) ? $event->geolocation->latitude : null);
+            $eventNode->set('field_geolocation_longitude', (isset($event->geolocation->longitude)) ? $event->geolocation->longitude : null);
+            $eventNode->set('field_geolocation_place_id', (isset($event->geolocation->{'place-id'})) ? $event->geolocation->{'place-id'} : null);
 
             $eventNode->save();
         }

--- a/src/EventDownloadService.php
+++ b/src/EventDownloadService.php
@@ -84,13 +84,13 @@ class EventDownloadService implements EventDownloadServiceInterface
                     $this->createNewCategoryTerm($tid, $name);
                 }
             }
-            
+
              if (count($nids) <= 0) {
                 $this->createNewEventNode($event);
             } else {
                 $this->updateEventNode($nids, $event);
             }
-            
+
             // check if future events relate to this event
              if (count($event->future_dates) > 0) {
                 $this->libcalFutureEventToNode($event->future_dates);
@@ -185,7 +185,7 @@ class EventDownloadService implements EventDownloadServiceInterface
         foreach ($event->category as $category) {
             array_push($category_tid_list,array('target_id' => $category->id));
         }
-        
+
 
         $params = [
             // The node entity bundle.
@@ -213,7 +213,6 @@ class EventDownloadService implements EventDownloadServiceInterface
             'field_calendar_id' => $event->calendar->id,
             'field_calendar_name' => $event->calendar->name,
             'field_campus' => (isset($event->campus) && is_object($event->campus) && isset($event->campus->name)) ? $event->campus->name : "",
-            'field_geolocation' => !empty($event->geolocation) ? $event->geolocation : "",
             //'field_future_dates' => $event->future_dates,
             'field_libcal_categories' => $category_tid_list,
             'field_libcal_color' => $event->color,
@@ -223,8 +222,12 @@ class EventDownloadService implements EventDownloadServiceInterface
             'field_seats' => $event->seats,
             'field_seats_taken' => !empty($event->seats_taken)? $event->seats_taken: 0,
             'field_wait_list' => !empty($event->wait_list) ? $event->wait_list: 0,
-            'field_past_event' => 0
+            'field_past_event' => 0,
+            'field_geolocation_latitude' => $event->geolocation->latitude,
+            'field_geolocation_longitude' => $event->geolocation->longitude,
+            'field_geolocation_place_id' => $event->geolocation->{'place-id'}
         ];
+
         $node = Node::create($params);
         $node->save();
 
@@ -275,7 +278,6 @@ class EventDownloadService implements EventDownloadServiceInterface
             $eventNode->set('field_calendar_id', $event->calendar->id);
             $eventNode->set('field_calendar_name', $event->calendar->name);
             $eventNode->set('field_campus', (isset($event->campus) && is_object($event->campus) && isset($event->campus->name)) ? $event->campus->name : "");
-            $eventNode->set('field_geolocation', $event->geolocation);
             //$eventNode->set('field_future_dates', $event->future_dates);
             $eventNode->set('field_libcal_categories', $category_tid_list);
             $eventNode->set('field_libcal_color', $event->color);
@@ -286,6 +288,9 @@ class EventDownloadService implements EventDownloadServiceInterface
             $eventNode->set('field_seats_taken',(!empty($event->seats_taken)? $event->seats_taken : 0));
             $eventNode->set('field_wait_list', (!empty($event->wait_list) ? $event->wait_list: 0));
             $eventNode->set('field_past_event', false);
+            $eventNode->set('field_geolocation_latitude', $event->geolocation->latitude);
+            $eventNode->set('field_geolocation_longitude', $event->geolocation->longitude);
+            $eventNode->set('field_geolocation_place_id', $event->geolocation->{'place-id'});
 
             $eventNode->save();
         }


### PR DESCRIPTION
Geolocation is represented as a JSON object with either a place-id
field, or latitude/longitude fields. We were previously trying to put
this whole object in to the database, which did not work.
This commit splits out the fields of the geolocation object.

Removed the `menu_ui` dependency, which is now part of core.